### PR TITLE
Fix for FF 34+

### DIFF
--- a/chrome/content/dta/manager/manager.js
+++ b/chrome/content/dta/manager/manager.js
@@ -1116,7 +1116,6 @@ const Dialog = {
 		delete Tree._downloads;
 		Tree = null;
 		FileExts = null;
-		Dialog = null;
 		return true;
 	}
 };


### PR DESCRIPTION
Need to remove
```javascript
		Dialog = null;
```
Since ```Dialog``` is ```const```, and now this is a syntax error that breaks code compilation.