### PR TITLE
Change "cmd + i" shortcut to Get Info

### DIFF
--- a/chrome/content/mac/manager.xul
+++ b/chrome/content/mac/manager.xul
@@ -31,6 +31,8 @@
 
 	<keyset id="mainkeys">
 		<key id="kLaunch" modifiers="accel" key="O" command="cmdLaunch" />
+		<key id="kGetInfo" modifiers="accel" key="I" command="cmdGetInfo" />
+		<key id="kSelectInv" modifiers="accel,shift" key="I" command="cmdSelectInv" />
 		<key id="kOpenFolder" modifiers="accel,shift" key="O" command="cmdOpenFolder" />
 		<key id="kRename" keycode="VK_RETURN" command="cmdRename"/>
 		<key id="kCloseMac" modifiers="accel" key="W" command="cmdClose" />


### PR DESCRIPTION
"cmd + i" is generally the standard for opening an information pane, at least on Mac OS. I think that it is beneficial that such a commonly used command to be more intuitive than "alt + i". Because of this change, Invert Selection was changed to "cmd + shift + I" which I personally think is fair.

I did not test this PR, please take it as a nudge not so much as contribution. I just looked around to find what I thought to be right place to edit.