### PR TITLE
Japanese translation 1st (Revised edition)

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,1170 @@
+{
+  "CRASH": {
+    "description": "Error Message",
+    "message": "内部ブラウザエラー"
+  },
+  "FILE_FAILED": {
+    "description": "Error Message",
+    "message": "ファイルアクセスエラー"
+  },
+  "NETWORK_FAILED": {
+    "description": "Error Message",
+    "message": "ネットワークエラー"
+  },
+  "SERVER_BAD_CONTENT": {
+    "description": "Error message",
+    "message": "見つかりません"
+  },
+  "SERVER_FAILED": {
+    "description": "Error message",
+    "message": "サーバーエラー"
+  },
+  "SERVER_FORBIDDEN": {
+    "description": "Error message",
+    "message": "許可されていません"
+  },
+  "SERVER_UNAUTHORIZED": {
+    "description": "Error message",
+    "message": "認証が必要です"
+  },
+  "addpaused": {
+    "description": "Action: Add paused",
+    "message": "一時停止状態で追加"
+  },
+  "cancel": {
+    "description": "Button text: Cancel",
+    "message": "キャンセル"
+  },
+  "canceled": {
+    "description": "Download status text",
+    "message": "キャンセルされました"
+  },
+  "colConnections": {
+    "description": "Table column in prefs/network",
+    "message": "同時接続数"
+  },
+  "colDomain": {
+    "description": "Table column in manager",
+    "message": "ドメイン"
+  },
+  "colETA": {
+    "description": "Table column in manager",
+    "message": "残り時間"
+  },
+  "colNameURL": {
+    "description": "Table column in manager",
+    "message": "ファイル名/URL"
+  },
+  "colPercent": {
+    "description": "Table column in manager",
+    "message": "ダウンロード済み %"
+  },
+  "colProgress": {
+    "description": "Table column in manager",
+    "message": "進捗状況"
+  },
+  "colSegments": {
+    "description": "Table column in manager",
+    "message": "セグメント"
+  },
+  "colSize": {
+    "description": "Table column in manager",
+    "message": "サイズ"
+  },
+  "colSpeed": {
+    "description": "Table column in manager",
+    "message": "速度"
+  },
+  "delete": {
+    "description": "button text",
+    "message": "削除"
+  },
+  "description": {
+    "description": "Description (keep it short); e.g. the description column in select",
+    "message": "説明"
+  },
+  "donate": {
+    "description": "Donate button",
+    "message": "寄付するよ！"
+  },
+  "done": {
+    "description": "Status text",
+    "message": "完了"
+  },
+  "download": {
+    "description": "Download (noun); e.g. Download column in select",
+    "message": "ダウンロード"
+  },
+  "extensionDescription": {
+    "description": "DownThemAll! tagline, displayed in about:addons; Please do NOT refer to a specific browser such as firefox, as we will probably support more than one",
+    "message": "ブラウザ用マスダウンローダー"
+  },
+  "fastfiltering": {
+    "description": "Label for Fast Filtering input",
+    "message": "高速フィルタリング"
+  },
+  "finishing": {
+    "description": "Status text",
+    "message": "完了しました"
+  },
+  "language": {
+    "description": "Lanuage Name in your language",
+    "message": "日本語 (JP)"
+  },
+  "language_code": {
+    "description": "Language code the locale will use, e.g. de or en-GB or pt-BR",
+    "message": "ja"
+  },
+  "links": {
+    "description": "Links tab label (short); select window",
+    "message": "リンク"
+  },
+  "mask": {
+    "description": "Renaming mask (short); used in e.g. select",
+    "message": "マスク"
+  },
+  "media": {
+    "description": "Media label (short)",
+    "message": "マスク"
+  },
+  "missing": {
+    "description": "Status text in manager",
+    "message": "見つかりません"
+  },
+  "ok": {
+    "description": "Button text; Used in message boxes",
+    "message": "OK"
+  },
+  "paused": {
+    "description": "Status text; manager",
+    "message": "一時停止"
+  },
+  "queued": {
+    "description": "Status text",
+    "message": "待機中"
+  },
+  "referrer": {
+    "description": "Label for \"Referrer\"",
+    "message": "リファラ"
+  },
+  "remember": {
+    "description": "Checkbox text for confirmation, e.g. when removing a download in manager",
+    "message": "この決定を覚えておく"
+  },
+  "rename": {
+    "description": "UI for renaming; currently unused",
+    "message": "名前変更"
+  },
+  "renmask": {
+    "description": "Renaming mask (long)",
+    "message": "名前変更マスク"
+  },
+  "reset": {
+    "description": "Button text; pref window",
+    "message": "リセット"
+  },
+  "running": {
+    "description": "Status text",
+    "message": "稼働中"
+  },
+  "save": {
+    "description": "Button text; e.g. prefs/Network",
+    "message": "保存"
+  },
+  "search": {
+    "description": "Placeholder text; manager status search field",
+    "message": "検索…"
+  },
+  "sizeB": {
+    "description": "Size formatting; bytes",
+    "message": "$S$B",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100b"
+      }
+    }
+  },
+  "sizeGB": {
+    "description": "Size formatting; giga bytes",
+    "message": "$S$GB",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100.200GB"
+      }
+    }
+  },
+  "sizeKB": {
+    "description": "Size formatting; kilo bytes",
+    "message": "$S$KB",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100.2KB"
+      }
+    }
+  },
+  "sizeMB": {
+    "description": "Size formatting; mega bytes",
+    "message": "$S$MB",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100.22MB"
+      }
+    }
+  },
+  "sizePB": {
+    "description": "Size formatting; peta bytes (you never know)",
+    "message": "$S$PB",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100.212PB"
+      }
+    }
+  },
+  "sizeTB": {
+    "description": "Size formatting; tera bytes (you never know)",
+    "message": "$S$TB",
+    "placeholders": {
+      "s": {
+        "content": "$1",
+        "example": "100.002TB"
+      }
+    }
+  },
+  "speedB": {
+    "description": "Speed formatting; bytes",
+    "message": "$SPEED$b/s",
+    "placeholders": {
+      "speed": {
+        "content": "$1",
+        "example": "100b/s"
+      }
+    }
+  },
+  "speedKB": {
+    "description": "Speed formatting; kilo bytes",
+    "message": "$SPEED$KB/s",
+    "placeholders": {
+      "speed": {
+        "content": "$1",
+        "example": "100.1KB/s"
+      }
+    }
+  },
+  "speedMB": {
+    "description": "Speed formatting; mega bytes",
+    "message": "$SPEED$MB/s",
+    "placeholders": {
+      "speed": {
+        "content": "$1",
+        "example": "100.20MB/s"
+      }
+    }
+  },
+  "title": {
+    "description": "Column text; Title label (short)",
+    "message": "タイトル"
+  },
+  "unlimited": {
+    "description": "Option text; Prefs/Network",
+    "message": "無制限"
+  },
+  "useonlyonce": {
+    "description": "Label for Use-Once checkboxes",
+    "message": "一度だけ使用"
+  },
+  "add_download": {
+    "description": "Action for adding a download",
+    "message": "ダウンロード追加"
+  },
+  "add_new": {
+    "description": "Button text (adding filters, limits and such)",
+    "message": "新規追加"
+  },
+  "add_paused_once": {
+    "description": "Checkbox label",
+    "message": "今回は一時停止で追加"
+  },
+  "add_paused_question": {
+    "description": "Messagebox text",
+    "message": "この決定を覚えて、今後新しいダウンロードを常に一時停止で追加しますか？"
+  },
+  "add_paused_title": {
+    "description": "Title for the add-paused dialog",
+    "message": "常に一時停止で追加しますか？"
+  },
+  "ask_again_later": {
+    "description": "Button text",
+    "message": "後でもう一度尋ねる"
+  },
+  "batch_batch": {
+    "description": "Button text",
+    "message": "バッチダウンロード"
+  },
+  "batch_desc": {
+    "description": "",
+    "message": "現在のURLには、バッチダウンロードの手順が含まれているようです。"
+  },
+  "batch_items": {
+    "description": "Messagebox info text for batch confirmations",
+    "message": "アイテム数:"
+  },
+  "batch_preview": {
+    "description": "Messagebox info text for batch confirmations",
+    "message": "プレビュー:"
+  },
+  "batch_question": {
+    "description": "Messagebox info text for batch confirmations",
+    "message": "これをバッチとして追加しますか？それとも単一のダウンロードとして追加しますか？"
+  },
+  "batch_single": {
+    "description": "Button text for batch confirmation",
+    "message": "単一のダウンロード"
+  },
+  "batch_title": {
+    "description": "Messagebox title for batch confirmations",
+    "message": "バッチダウンロード"
+  },
+  "cancel_download": {
+    "description": "Action to cancel downloads, e.g. from the context menu",
+    "message": "キャンセル"
+  },
+  "cannot_be_empty": {
+    "description": "Error message when an input field is empty but has to have a value",
+    "message": "この項目は空欄に出来ません"
+  },
+  "change_later_reminder": {
+    "description": "Checkbox label text for decision confirmations",
+    "message": "この設定は後で設定項目で変更できます"
+  },
+  "check_selected_items": {
+    "description": "Menu text",
+    "message": "選択したアイテムをチェック"
+  },
+  "conflict_overwrite": {
+    "description": "Option text; prefs/general",
+    "message": "上書き"
+  },
+  "conflict_prompt": {
+    "description": "Option text; prefs/general",
+    "message": "プロンプト"
+  },
+  "conflict_rename": {
+    "description": "Option text; prefs/general",
+    "message": "名前変更"
+  },
+  "create_filter": {
+    "description": "Button text; Create filter dialog; prefs/filters",
+    "message": "フィルタ作成"
+  },
+  "custom_filename": {
+    "description": "Label text; single window",
+    "message": "カスタムファイル名"
+  },
+  "deffilter_all": {
+    "description": "Filter label for the All files filter",
+    "message": "全てのファイル"
+  },
+  "deffilter_arch": {
+    "description": "Filter label for the Archives filter",
+    "message": "書庫ファイル (zip, rar, 7z, …)"
+  },
+  "deffilter_aud": {
+    "description": "Filter label for the Audio filter",
+    "message": "音楽ファイル (mp3, flac, wav, …)"
+  },
+  "deffilter_bin": {
+    "description": "Filter label for the Software filter",
+    "message": "実行可能ファイル (exe, msi, …)"
+  },
+  "deffilter_doc": {
+    "description": "Filter label for the Documents filter",
+    "message": "書庫ファイル (pdf, odf, docx, …)"
+  },
+  "deffilter_img": {
+    "description": "Filter label for the Images filter",
+    "message": "画像ファイル (jpeg, png, gif, …)"
+  },
+  "deffilter_imggif": {
+    "description": "Filter label for the GIF filter",
+    "message": "GIF画像"
+  },
+  "deffilter_imgjpg": {
+    "description": "Filter label for the JPEG filter",
+    "message": "JPEG画像"
+  },
+  "deffilter_imgpng": {
+    "description": "Filter label for the PNG filter",
+    "message": "PNG画像"
+  },
+  "deffilter_vid": {
+    "description": "Filter label for the Videos filter",
+    "message": "動画ファイル (mp4, webm, mkv, …)"
+  },
+  "disable_other_filters": {
+    "description": "Checkbox label. Keep it short",
+    "message": "他を無効にする"
+  },
+  "download_verb": {
+    "description": "Download (verb/action); e.g. in single and select buttons",
+    "message": "ダウンロード"
+  },
+  "dta_regular_all": {
+    "description": "Menu text",
+    "message": "DownThemAll! - 全てのタブ"
+  },
+  "dta_turbo_all": {
+    "description": "Menu text",
+    "message": "OneClick! - 全てのタブ"
+  },
+  "dta_regular": {
+    "description": "Regular dta action; Menu text",
+    "message": "DownThemAll!"
+  },
+  "dta_regular_image": {
+    "description": "Menu text",
+    "message": "画像をDownThemAll! で保存する"
+  },
+  "dta_regular_link": {
+    "description": "Menu text",
+    "message": "リンク先をDownThemAll! で保存する"
+  },
+  "dta_regular_media": {
+    "description": "Menu text",
+    "message": "メディアをDownThemAll! で保存する"
+  },
+  "dta_regular_selection": {
+    "description": "Menu text",
+    "message": "選択項目をDownThemAll! で保存する"
+  },
+  "dta_turbo": {
+    "description": "OneClick! action; Menu text",
+    "message": "OneClick!"
+  },
+  "dta_turbo_image": {
+    "description": "Menu text",
+    "message": "画像をOneClick! で保存する"
+  },
+  "dta_turbo_link": {
+    "description": "Menu text",
+    "message": "リンク先をOneClick! で保存する"
+  },
+  "dta_turbo_media": {
+    "description": "Menu text",
+    "message": "メディアをOneClick! で保存する"
+  },
+  "dta_turbo_selection": {
+    "description": "Menu text",
+    "message": "選択項目をOneClick! で保存する"
+  },
+  "error_invalidMask": {
+    "description": "Error message; single/select window",
+    "message": "無効な名前変更マスク"
+  },
+  "error_invalidReferrer": {
+    "description": "Error message; single window",
+    "message": "無効なリファラ"
+  },
+  "error_invalidURL": {
+    "description": "Error message; single window",
+    "message": "無効なURL"
+  },
+  "error_noItemsSelected": {
+    "description": "Error Message; select window",
+    "message": "アイテムが選択されていません"
+  },
+  "fastfilter_placeholder": {
+    "description": "Placeholder for fastfilter inputs",
+    "message": "ワイルドカード表現か正規表現"
+  },
+  "filter_at_least_one": {
+    "description": "Error message when no filter types are selected for a filter in the preferences UI",
+    "message": "少なくとも1つのフィルタータイプを選択する必要があります！"
+  },
+  "filter_create_title": {
+    "description": "Message box title",
+    "message": "新規フィルタ作成"
+  },
+  "filter_expression": {
+    "description": "Message box label",
+    "message": "フィルタ様式"
+  },
+  "filter_label": {
+    "description": "Message box label",
+    "message": "フィルタラベル"
+  },
+  "filter_type_link": {
+    "description": "Message box checkbox label",
+    "message": "リンクフィルタ"
+  },
+  "filter_type_media": {
+    "description": "Message box checkbox label",
+    "message": "メディアフィルタ"
+  },
+  "filter_types": {
+    "description": "Message box label",
+    "message": "フィルタタイプ"
+  },
+  "force_start": {
+    "description": "Menu text",
+    "message": "強制的に開始"
+  },
+  "information_title": {
+    "description": "Used in message boxes",
+    "message": "案内"
+  },
+  "invalid_domain_pref": {
+    "description": "Error message in prefs/network",
+    "message": "無効なドメイン"
+  },
+  "invert_selection": {
+    "description": "Menu text",
+    "message": "選択を反転"
+  },
+  "key_alt": {
+    "description": "Short for Alt-Key",
+    "message": "Alt"
+  },
+  "key_ctrl": {
+    "description": "Short for Ctrl-Key",
+    "message": "Ctrl"
+  },
+  "key_delete": {
+    "description": "Short for Delete-key",
+    "message": "Del"
+  },
+  "key_end": {
+    "description": "Short for End-key",
+    "message": "End"
+  },
+  "key_home": {
+    "description": "Short for home key",
+    "message": "Home"
+  },
+  "key_pagedown": {
+    "description": "Short for pagedown-key",
+    "message": "PageDown"
+  },
+  "key_pageup": {
+    "description": "Short for PageUp-key",
+    "message": "PageUp"
+  },
+  "limited_to": {
+    "description": "Label text; used in prefs/network",
+    "message": "〜に限定"
+  },
+  "manager_status_items": {
+    "description": "Status bar text; manager",
+    "message": "$TOTAL$ のダウンロードのうち $COMPLETE$ が完了（ $SHOWING$ が表示）、 $RUNNING$ が実行中",
+    "placeholders": {
+      "complete": {
+        "content": "$1",
+        "example": "10"
+      },
+      "running": {
+        "content": "$4",
+        "example": "4"
+      },
+      "showing": {
+        "content": "$3",
+        "example": "90"
+      },
+      "total": {
+        "content": "$2",
+        "example": "100"
+      }
+    }
+  },
+  "manager_short": {
+    "description": "Menu text",
+    "message": "マネージャ"
+  },
+  "manager_title": {
+    "description": "Window/tab title",
+    "message": "DownThemAll! マネージャ"
+  },
+  "mask_default": {
+    "description": "Status text; Used in the mask column, select window",
+    "message": "デフォルトマスク"
+  },
+  "move_bottom": {
+    "description": "Action for moving a download to the bottom",
+    "message": "一番下に移動"
+  },
+  "move_down": {
+    "description": "Action for moving a download down",
+    "message": "下に移動"
+  },
+  "move_top": {
+    "description": "Action for moving a download to the top",
+    "message": "一番上に移動"
+  },
+  "move_up": {
+    "description": "Action for moving a download up",
+    "message": "上に移動"
+  },
+  "nagging_message": {
+    "description": "Donation nagging message; displayed as a notification bar in manager",
+    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。 イケメンさんありがとうイケメンさん！",
+    "placeholders": {
+      "downloads": {
+        "content": "$1",
+        "example": ""
+      }
+    }
+  },
+  "never_ask_again": {
+    "description": "Donation button",
+    "message": "再度確認しない"
+  },
+  "no_links": {
+    "description": "Notification text",
+    "message": "リンク先が見つかりません！"
+  },
+  "noitems_label": {
+    "description": "Status bar text in select",
+    "message": "アイテムが選択されていません"
+  },
+  "numitems_label": {
+    "description": "Status bar text in select; Number of items selected (label)",
+    "message": "$ITEMS$個のアイテムを選択しました",
+    "placeholders": {
+      "items": {
+        "content": "$1",
+        "example": "1000"
+      }
+    }
+  },
+  "open_directory": {
+    "description": "Menu text; manager context",
+    "message": "フォルダを開く"
+  },
+  "open_file": {
+    "description": "Menu text; manager context",
+    "message": "ファイルを開く"
+  },
+  "open_link": {
+    "description": "Menu text; select window",
+    "message": "リンクを開く"
+  },
+  "options_filters": {
+    "description": "Pref tab text",
+    "message": "フィルタ"
+  },
+  "options_general": {
+    "description": "Pref tab text",
+    "message": "一般"
+  },
+  "options_network": {
+    "description": "Pref tab text",
+    "message": "ネットワーク"
+  },
+  "pause_download": {
+    "description": "Action for pausing a download",
+    "message": "一時停止"
+  },
+  "pref_add_paused": {
+    "description": "Preferences/General",
+    "message": "すぐに開始せず、新しいダウンロードを一時停止状態で追加する"
+  },
+  "pref_concurrent_downloads": {
+    "description": "Preferences/Network",
+    "message": "同時ダウンロード数"
+  },
+  "pref_finish_notification": {
+    "description": "Preferences/General",
+    "message": "キューのダウンロードが完了したときに通知を表示する"
+  },
+  "pref_global_turbo": {
+    "description": "Preferences/General",
+    "message": "ブラウザのボタンはOne Click! にする必要がある"
+  },
+  "pref_hide_context": {
+    "description": "Preferences/General",
+    "message": "一般的なコンテキストメニューを表示しない"
+  },
+  "pref_manager_tooltip": {
+    "description": "Preferences/General",
+    "message": "マネージャのタブにツールチップを表示する"
+  },
+  "pref_open_manager_on_queue": {
+    "description": "Preferences/General",
+    "message": "いくつかのダウンロードをキューに入れた後、マネージャタブを開く"
+  },
+  "pref_queue_notification": {
+    "description": "Preferences/General",
+    "message": "新しいダウンロードをキューに入れた時、通知を表示する"
+  },
+  "pref_remove_missing_on_init": {
+    "description": "Preferences/General",
+    "message": "再起動後に不足しているダウンロードを削除する"
+  },
+  "pref_show_urls": {
+    "description": "Preferences/General",
+    "message": "ファイル名の代わりにURLを表示する"
+  },
+  "pref_text_links": {
+    "description": "Preferences/General",
+    "message": "Webサイトの文字列でリンクを見つけてみる（但し、遅い）"
+  },
+  "pref_manager": {
+    "description": "Preferences/General; group text",
+    "message": "マネージャ"
+  },
+  "pref_netglobal": {
+    "description": "Preferences/General; group text",
+    "message": "グローバルネットワークの制限"
+  },
+  "pref_queueing": {
+    "description": "Preferences/General; group text",
+    "message": "ダウンロードのキューイング"
+  },
+  "pref_ui": {
+    "description": "Preferences/General; group text",
+    "message": "ユーザーインターフェイス"
+  },
+  "prefs_conflicts": {
+    "description": "Preferences/General; group text",
+    "message": "ファイルが存在する場合"
+  },
+  "prefs_short": {
+    "description": "Menu text; Preferences",
+    "message": "設定"
+  },
+  "prefs_title": {
+    "description": "Window/tab title; Preferences",
+    "message": "DownThemAll! 設定"
+  },
+  "queue_finished": {
+    "description": "Notification text",
+    "message": "ダウンロードキューが完了しました"
+  },
+  "queued_download": {
+    "description": "Notification text; single download",
+    "message": "１件のダウンロード待ち"
+  },
+  "queued_downloads": {
+    "description": "Notification text; multiple downloads",
+    "message": "$COUNT$ 件のダウンロード待ち",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "100"
+      }
+    }
+  },
+  "remove_all_complete_downloads": {
+    "description": "Menu text",
+    "message": "ダウンロード済みを削除する"
+  },
+  "remove_all_downloads": {
+    "description": "Menu text",
+    "message": "全て削除する"
+  },
+  "remove_all_downloads_question": {
+    "description": "Messagebox text",
+    "message": "全てのダウンロードを削除しますか？"
+  },
+  "remove_batch_downloads": {
+    "description": "Menu text",
+    "message": "現在のバッチを削除する"
+  },
+  "remove_batch_downloads_question": {
+    "description": "Messagebox text",
+    "message": "現在選択されているダウンロードと同じバッチから全てのダウンロードを削除しますか？"
+  },
+  "remove_complete_downloads": {
+    "description": "Action for removing complete downloads",
+    "message": "完了したダウンロードを削除する"
+  },
+  "remove_complete_downloads_question": {
+    "description": "Messagebox text",
+    "message": "全ての完了したダウンロードを削除しますか？"
+  },
+  "remove_complete_filter_downloads_question": {
+    "description": "Messagebox text",
+    "message": "「$FILTER$」フィルタに一致する完了したダウンロードをすべて削除しますか？",
+    "placeholders": {
+      "filter": {
+        "content": "$1",
+        "example": "JPEG Images"
+      }
+    }
+  },
+  "remove_complete_selection_downloads_question": {
+    "description": "Messagebox text",
+    "message": "選択範囲内の完了したダウンロードをすべて削除しますか？"
+  },
+  "remove_domain_complete_downloads": {
+    "description": "Menu text",
+    "message": "現在のドメインから完了したダウンロードを削除する"
+  },
+  "remove_domain_complete_downloads_question": {
+    "description": "Messagebox text",
+    "message": "ドメイン「$DOMAIN$」から完了したダウンロードを全て削除しますか？",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "example.org"
+      }
+    }
+  },
+  "remove_domain_downloads": {
+    "description": "Menu text",
+    "message": "現在のドメインを削除する"
+  },
+  "remove_domain_downloads_question": {
+    "description": "Messagebox text",
+    "message": "ドメイン「$DOMAIN$」から全てのダウンロードを削除しますか？",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "example.org"
+      }
+    }
+  },
+  "remove_download": {
+    "description": "Action for removing a download, no matter what state",
+    "message": "ダウンロードを削除する"
+  },
+  "remove_download_question": {
+    "description": "Messagebox text",
+    "message": "選択したダウンロードを削除しますか？"
+  },
+  "remove_downloads": {
+    "description": "Menu text",
+    "message": "ダウンロードを削除する"
+  },
+  "remove_downloads_title": {
+    "description": "Messagebox title; manager",
+    "message": "ダウンロードを削除しますか？"
+  },
+  "remove_failed_downloads": {
+    "description": "Menu text",
+    "message": "失敗したダウンロードを削除する"
+  },
+  "remove_failed_downloads_question": {
+    "description": "Messagebox text",
+    "message": "失敗したダウンロードを全て削除しますか？"
+  },
+  "remove_filter_downloads_question": {
+    "description": "Mesagebox text",
+    "message": "「$FILTER$」フィルターに一致する全てのダウンロードを削除しますか？",
+    "placeholders": {
+      "filter": {
+        "content": "$1",
+        "example": "JPEG Images"
+      }
+    }
+  },
+  "remove_missing": {
+    "description": "Menu text",
+    "message": "不明なダウンロードを削除する"
+  },
+  "remove_missing_downloads_question": {
+    "description": "Messagebox text",
+    "message": "不明なダウンロードを全て削除しますか？"
+  },
+  "remove_paused_downloads": {
+    "description": "Menu text",
+    "message": "一時停止中のダウンロードを削除する"
+  },
+  "remove_paused_downloads_question": {
+    "description": "Messagebox text",
+    "message": "一時停止中のダウンロードを全て削除しますか？"
+  },
+  "remove_selected_complete_downloads": {
+    "description": "Menu text",
+    "message": "選択中の完了したダウンロードを削除する"
+  },
+  "remove_selected_complete_downloads_question": {
+    "description": "Messagebox text",
+    "message": "選択中の完了したダウンロードを全て削除しますか？"
+  },
+  "remove_selected_downloads": {
+    "description": "Menu text",
+    "message": "選択を削除"
+  },
+  "renamer_batch": {
+    "description": "Mask text; see mask button",
+    "message": "バッチ番号"
+  },
+  "renamer_d": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 日"
+  },
+  "renamer_date": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加"
+  },
+  "renamer_domain": {
+    "description": "Mask text; see mask button",
+    "message": "Domain Name (TLD)"
+  },
+  "renamer_ext": {
+    "description": "Mask text; see mask button",
+    "message": "File Extension"
+  },
+  "renamer_hh": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 時"
+  },
+  "renamer_host": {
+    "description": "Mask text; see mask button",
+    "message": "ホスト名"
+  },
+  "renamer_idx": {
+    "description": "Mask text; see mask button",
+    "message": "バッチ内番号"
+  },
+  "renamer_info": {
+    "description": "Mask text; see mask button; do NOT translate any mentions of \"flat\"!",
+    "message": "*flatsubdirs*などの 'flat'を追加すると、値のすべてのスラッシュが置き換えられ、ディレクトリが作成されません"
+  },
+  "renamer_m": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 月"
+  },
+  "renamer_mm": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 分"
+  },
+  "renamer_name": {
+    "description": "Mask text; see mask button",
+    "message": "ファイル名"
+  },
+  "renamer_num": {
+    "description": "Mask text; see mask button",
+    "message": "*batch* へのエイリアス"
+  },
+  "renamer_qstring": {
+    "description": "Mask text; see mask button",
+    "message": "クエリ文字列"
+  },
+  "renamer_ref": {
+    "description": "Mask text; see mask button",
+    "message": "リファラ"
+  },
+  "renamer_refdomain": {
+    "description": "Mask text; see mask button",
+    "message": "ドメイン名リファラ(TLD)"
+  },
+  "renamer_refext": {
+    "description": "Mask text; see mask button",
+    "message": "ファイル拡張子リファラ"
+  },
+  "renamer_refhost": {
+    "description": "Mask text; see mask button",
+    "message": "ホスト名リファラ"
+  },
+  "renamer_refname": {
+    "description": "Mask text; see mask button",
+    "message": "ファイル名リファラ"
+  },
+  "renamer_refqstring": {
+    "description": "Mask text; see mask button",
+    "message": "クエリ文字列リファラ"
+  },
+  "renamer_refsubdirs": {
+    "description": "Mask text; see mask button",
+    "message": "パス名リファラ"
+  },
+  "renamer_refurl": {
+    "description": "Mask text; see mask button",
+    "message": "URLリファラ (プロトコル無し)"
+  },
+  "renamer_ss": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 秒"
+  },
+  "renamer_subdirs": {
+    "description": "Mask text; see mask button",
+    "message": "パス名"
+  },
+  "renamer_tags": {
+    "description": "Mask text; see mask button",
+    "message": "マスクタグ名変更"
+  },
+  "renamer_text": {
+    "description": "Mask text; see mask button",
+    "message": "説明文"
+  },
+  "renamer_title": {
+    "description": "Mask text; see mask button",
+    "message": "タイトル文字列"
+  },
+  "renamer_url": {
+    "description": "Mask text; see mask button",
+    "message": "URL (プロトコル無し)"
+  },
+  "renamer_y": {
+    "description": "Mask text; see mask button",
+    "message": "日付追加 - 年"
+  },
+  "reset_confirmations": {
+    "description": "Button text; pref/General",
+    "message": "記憶された確認をリセットする"
+  },
+  "reset_confirmations_done": {
+    "description": "Messagebox text; pref/General",
+    "message": "以前に記憶した確認はすべてリセットされました！"
+  },
+  "reset_layouts": {
+    "description": "Button text; pref/General",
+    "message": "ユーザーインターフェイスのカスタマイズをリセットする"
+  },
+  "reset_layouts_done": {
+    "description": "Messagebox text; pref/General",
+    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ ウィンドウ/タブの再読み込みが必要になる場合があります。"
+  },
+  "resume_download": {
+    "description": "Action for resuming a download",
+    "message": "再開"
+  },
+  "select_all": {
+    "description": "Menu text; e.g. select context",
+    "message": "全て選択"
+  },
+  "select_checked": {
+    "description": "Menu text; select context",
+    "message": "チェックされたアイテムを選択"
+  },
+  "select_none": {
+    "description": "Menu text; select context",
+    "message": "何も選択しない"
+  },
+  "select_title": {
+    "description": "Title of the select window",
+    "message": "DownThemAll! - ダウンロードの選択"
+  },
+  "set_mask": {
+    "description": "Menu text; select window",
+    "message": "名前変更マスクを設定する"
+  },
+  "single_batchexamples": {
+    "description": "Header text; single window",
+    "message": "バッチがサポートされています。例:"
+  },
+  "single_header": {
+    "description": "Header text; single window",
+    "message": "ダウンロードURL（リンク）およびその他のオプションを入力します"
+  },
+  "single_title": {
+    "description": "Title of single window",
+    "message": "DownThemAll! - リンクを追加"
+  },
+  "size_progress": {
+    "description": "Status text; manager size column",
+    "message": "$TOTAL$ のうち $WRITTEN$",
+    "placeholders": {
+      "total": {
+        "content": "$2",
+        "example": ""
+      },
+      "written": {
+        "content": "$1",
+        "example": ""
+      }
+    }
+  },
+  "size_unknown": {
+    "description": "Status text; manager size column",
+    "message": "不明"
+  },
+  "sizes_huge": {
+    "description": "Menu text; manager size column dropdown",
+    "message": "巨大 (> $HIGH$)",
+    "placeholders": {
+      "high": {
+        "content": "$1",
+        "example": "1GB"
+      }
+    }
+  },
+  "sizes_large": {
+    "description": "Menu text; manager size column dropdown",
+    "message": "大 ($LOW$ - $HIGH$)",
+    "placeholders": {
+      "high": {
+        "content": "$2",
+        "example": "10MB"
+      },
+      "low": {
+        "content": "$1",
+        "example": "1MB"
+      }
+    }
+  },
+  "sizes_medium": {
+    "description": "Menu text; manager size column dropdown",
+    "message": "中 ($LOW$ - $HIGH$)",
+    "placeholders": {
+      "high": {
+        "content": "$2",
+        "example": "10MB"
+      },
+      "low": {
+        "content": "$1",
+        "example": "1MB"
+      }
+    }
+  },
+  "sizes_small": {
+    "description": "Menu text; manager size column dropdown",
+    "message": "小 ($LOW$ - $HIGH$)",
+    "placeholders": {
+      "high": {
+        "content": "$2",
+        "example": "10MB"
+      },
+      "low": {
+        "content": "$1",
+        "example": "1MB"
+      }
+    }
+  },
+  "statusNetwork_active_title": {
+    "description": "Status bar tooltip; manager network icon",
+    "message": "新しいダウンロードが開始されます"
+  },
+  "statusNetwork_inactive_title": {
+    "description": "Status bar tooltip; manager network icon",
+    "message": "新しいダウンロードは開始されません"
+  },
+  "toggle_selected_items": {
+    "description": "Menu text; select",
+    "message": "選択したアイテムのチェックを切り替える"
+  },
+  "tooltip_date": {
+    "description": "Tooltip text; manager/downloads",
+    "message": "日付追加:"
+  },
+  "tooltip_eta": {
+    "description": "Tooltip text; manager/downloads; Time",
+    "message": "残り時間:"
+  },
+  "tooltip_from": {
+    "description": "Tooltip text; manager/downloads; source URL",
+    "message": "From:"
+  },
+  "tooltip_size": {
+    "description": "Tooltip text; manager/downloads",
+    "message": "サイズ:"
+  },
+  "tooltip_speed_average": {
+    "description": "Tooltip text; manager/downloads",
+    "message": "平均:"
+  },
+  "tooltip_speed_current": {
+    "description": "Tooltip text; manager/downloads",
+    "message": "現在:"
+  },
+  "uncheck_selected_items": {
+    "description": "Menu text; select",
+    "message": "選択したアイテムのチェックを外す"
+  }
+}


### PR DESCRIPTION
I corrected the pointed out part and translated everything except the part that I decided to be fine.
I checked the operation with Firefox69 of Windows10, Firefox69 of Debian Buster and Firefox69 of FreeBSD12p10, and confirmed that there was no problem in Japanese display.
Please use it if you like.
https://i.imgur.com/waZ6UZ4.png
https://i.imgur.com/xWJ7ksh.png