### PR TITLE
Japanese translation 4th

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -292,11 +292,11 @@
     "description": "Error message; single window"
   },
   "error_noabsolutepath": {
-    "message": "サブフォルダからの相対パスを指定して下さい\\n(絶対パスはブラウザ側で対応しておりません)",
+    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ側で対応しておりません)",
     "description": "Error Message; select/single window"
   },
   "error_nodotsinpath": {
-    "message": "フォルダ名の先頭に\".\"を使わないで下さい\\n(ブラウザ側で対応しておりません)",
+    "message": "フォルダ名の先頭に\".\"を使わないで下さい\n(ブラウザ側で対応しておりません)",
     "description": "Error Message; select/single window"
   },
   "error_noItemsSelected": {
@@ -486,7 +486,7 @@
     "description": "Action for moving a download up"
   },
   "nagging_message": {
-    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。\\n皆様のご協力、心よりお待ち致しております。",
+    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。\n皆様のご協力、心よりお待ち致しております。",
     "description": "Donation nagging message; displayed as a notification bar in manager",
     "placeholders": {
       "downloads": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -292,7 +292,7 @@
     "description": "Error message; single window"
   },
   "error_noabsolutepath": {
-    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ非対応)",
+    "message": "サブフォルダからの相対パスを指定して下さい(絶対パスはブラウザ非対応)",
     "description": "Error Message; select/single window"
   },
   "error_nodotsinpath": {
@@ -428,7 +428,7 @@
     "description": "Menu text"
   },
   "manager_status_items": {
-    "message": "$TOTAL$ のダウンロードのうち $COMPLETE$ が完了 ($SHOWING$ が表示)、 $RUNNING$ が実行中",
+    "message": "$TOTAL$ のダウンロードのうち $COMPLETE$ が完了 ($SHOWING$ が表示)、$RUNNING$ が実行中",
     "description": "Status bar text; manager",
     "placeholders": {
       "complete": {
@@ -964,7 +964,7 @@
     "description": "Button text; pref/General"
   },
   "reset_layouts_done": {
-    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ ウィンドウ/タブの再読み込みが必要になる場合があります。",
+    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ウィンドウ/タブの再読み込みが必要になる場合があります。",
     "description": "Messagebox text; pref/General"
   },
   "resume_download": {
@@ -1282,4 +1282,3 @@
     "description": "Error message"
   }
 }
-

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -292,11 +292,11 @@
     "description": "Error message; single window"
   },
   "error_noabsolutepath": {
-    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ非対応)",
+    "message": "サブフォルダからの相対パスを指定して下さい\\n(絶対パスはブラウザ側で対応しておりません)",
     "description": "Error Message; select/single window"
   },
   "error_nodotsinpath": {
-    "message": "フォルダ名の先頭に\".\"を使わないで下さい(ブラウザ非対応)",
+    "message": "フォルダ名の先頭に\".\"を使わないで下さい\\n(ブラウザ側で対応しておりません)",
     "description": "Error Message; select/single window"
   },
   "error_noItemsSelected": {
@@ -486,7 +486,7 @@
     "description": "Action for moving a download up"
   },
   "nagging_message": {
-    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。 皆様のご協力、心よりお待ち致しております。",
+    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。\\n皆様のご協力、心よりお待ち致しております。",
     "description": "Donation nagging message; displayed as a notification bar in manager",
     "placeholders": {
       "downloads": {
@@ -964,7 +964,7 @@
     "description": "Button text; pref/General"
   },
   "reset_layouts_done": {
-    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ ウィンドウ/タブの再読み込みが必要になる場合があります。",
+    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ \\nウィンドウ/タブの再読み込みが必要になる場合があります。",
     "description": "Messagebox text; pref/General"
   },
   "resume_download": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -292,11 +292,11 @@
     "description": "Error message; single window"
   },
   "error_noabsolutepath": {
-    "message": "サブフォルダーの絶対パスはブラウザでサポートされていません",
+    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ非対応)",
     "description": "Error Message; select/single window"
   },
   "error_nodotsinpath": {
-    "message": "サブフォルダー内のドット（.）はブラウザでサポートされていません",
+    "message": "フォルダ名の先頭に\".\"を使わないで下さい(ブラウザ非対応)",
     "description": "Error Message; select/single window"
   },
   "error_noItemsSelected": {
@@ -428,7 +428,7 @@
     "description": "Menu text"
   },
   "manager_status_items": {
-    "message": "$TOTAL$ のダウンロードのうち $COMPLETE$ が完了（ $SHOWING$ が表示）、 $RUNNING$ が実行中",
+    "message": "$TOTAL$ のダウンロードのうち $COMPLETE$ が完了 ($SHOWING$ が表示)、 $RUNNING$ が実行中",
     "description": "Status bar text; manager",
     "placeholders": {
       "complete": {
@@ -574,23 +574,23 @@
     "description": "Preferences/General"
   },
   "pref_button_type": {
-    "message": "DownThemAll! ボタン:",
+    "message": "DownThemAll! アイコンクリック時:",
     "description": "label"
   },
   "pref_button_type_dta": {
-    "message": "DownThemAll！ 選択",
+    "message": "DownThemAll! 選択画面",
     "description": "label"
   },
   "pref_button_type_manager": {
-    "message": "マネージャーを開く",
+    "message": "マネージャを開く",
     "description": "label"
   },
   "pref_button_type_popup": {
-    "message": "ポップアップメニュー",
+    "message": "メニュー展開",
     "description": "label"
   },
   "pref_button_type_turbo": {
-    "message": "OneClick!",
+    "message": "OneClick! ダウンロード",
     "description": "label"
   },
   "pref_concurrent_downloads": {
@@ -642,7 +642,7 @@
     "description": "pref text"
   },
   "pref_retry_time": {
-    "message": "毎回再試行する（数分で）",
+    "message": "再試行の間隔 (分単位)",
     "description": "pref text"
   },
   "pref_show_urls": {
@@ -654,7 +654,7 @@
     "description": "checkbox text"
   },
   "pref_text_links": {
-    "message": "Webサイトの文字列でリンクを見つけてみる（但し、遅い）",
+    "message": "Webサイトの文字列でリンクを見つけてみる (但し、遅い)",
     "description": "Preferences/General"
   },
   "pref_ui": {
@@ -1050,7 +1050,7 @@
     "description": "Header text; single window"
   },
   "single_header": {
-    "message": "ダウンロードURL（リンク）およびその他のオプションを入力します",
+    "message": "ダウンロードURL(リンク)およびその他のオプションを入力します",
     "description": "Header text; single window"
   },
   "single_title": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -292,11 +292,11 @@
     "description": "Error message; single window"
   },
   "error_noabsolutepath": {
-    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ側で対応しておりません)",
+    "message": "サブフォルダからの相対パスを指定して下さい\n(絶対パスはブラウザ非対応)",
     "description": "Error Message; select/single window"
   },
   "error_nodotsinpath": {
-    "message": "フォルダ名の先頭に\".\"を使わないで下さい\n(ブラウザ側で対応しておりません)",
+    "message": "フォルダ名の先頭に\".\"を使わないで下さい(ブラウザ非対応)",
     "description": "Error Message; select/single window"
   },
   "error_noItemsSelected": {
@@ -486,7 +486,7 @@
     "description": "Action for moving a download up"
   },
   "nagging_message": {
-    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。\n皆様のご協力、心よりお待ち致しております。",
+    "message": "これまでDownThemAllで$DOWNLOADS$ダウンロードを追加しました！ 通常のユーザーとして、さらなる開発を支援するために寄付を検討することができます。 皆様のご協力、心よりお待ち致しております。",
     "description": "Donation nagging message; displayed as a notification bar in manager",
     "placeholders": {
       "downloads": {
@@ -964,7 +964,7 @@
     "description": "Button text; pref/General"
   },
   "reset_layouts_done": {
-    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ \\nウィンドウ/タブの再読み込みが必要になる場合があります。",
+    "message": "以前に記憶したレイアウトのカスタマイズはすべてリセットされました！ ウィンドウ/タブの再読み込みが必要になる場合があります。",
     "description": "Messagebox text; pref/General"
   },
   "resume_download": {
@@ -1282,3 +1282,4 @@
     "description": "Error message"
   }
 }
+


### PR DESCRIPTION
Hi Nils. Is your job going well?

I was able to write even more natural Japanese resources by running DownThemAll with the latest code. I am very grateful for the teaching from Nils last night😄
The changes are as follows.

1. Translated parts that are difficult to communicate in the direct translation without changing the nuances
2. In order to save the file size as much as possible, the parentheses that had been changed to 2-byte characters were changed to 1-byte characters

Use a file if you like.

I'd like to ask a question, how can I write in json to make a line break in the screenshot (Request for donation) etc. It was impossible with "\n"...
Or should I shorten the translation?

https://i.imgur.com/ttltAp1.png