### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -39,7 +39,7 @@ class Entry {
     let hit = false;
     this.message = entry.message.replace(/\$[A-Z0-9]+\$/g, (r: string) => {
       hit = true;
-      const id = r.substr(1, r.length - 2).toLocaleLowerCase();
+      const id = r.slice(1, -1).toLocaleLowerCase();
       const placeholder = entry.placeholders[id];
       if (!placeholder || !placeholder.content) {
         throw new Error(`Invalid placeholder: ${id}`);
@@ -53,7 +53,7 @@ class Entry {
 
   localize(args: any[]) {
     return this.message.replace(/\$\d+\$/g, (r: string) => {
-      const idx = parseInt(r.substr(1, r.length - 2), 10) - 1;
+      const idx = parseInt(r.slice(1, -1), 10) - 1;
       return args[idx] || "";
     });
   }
@@ -271,8 +271,8 @@ function localize_<T extends HTMLElement | DocumentFragment>(elem: T): T {
         }
         continue;
       }
-      const attr = piece.substr(0, idx).trim();
-      piece = piece.substr(idx + 1).trim();
+      const attr = piece.substring(0, idx).trim();
+      piece = piece.slice(idx + 1).trim();
       el.setAttribute(attr, _(piece));
     }
   }

--- a/lib/manager/renamer.ts
+++ b/lib/manager/renamer.ts
@@ -91,11 +91,11 @@ export default class Renamer {
 
   get p_qstring() {
     const {search} = this.d.uURL;
-    return search && search.substr(1).replace(/\/+/g, "-");
+    return search && search.slice(1).replace(/\/+/g, "-");
   }
 
   get p_url() {
-    return this.d.usable.substr(this.d.uURL.protocol.length + 2);
+    return this.d.usable.slice(this.d.uURL.protocol.length + 2);
   }
 
   get p_batch() {
@@ -160,11 +160,11 @@ export default class Renamer {
       return null;
     }
     const {search} = ref;
-    return search && search.substr(1).replace(/\/+/g, "-");
+    return search && search.slice(1).replace(/\/+/g, "-");
   }
 
   get p_refurl() {
-    return this.d.usableReferrer.substr(
+    return this.d.usableReferrer.slice(
       this.d.uReferrer.protocol.length + 2);
   }
 
@@ -198,10 +198,10 @@ export default class Renamer {
     const self: any = this;
     const baseMask = subfolder ? `${subfolder}/${mask}` : mask;
     return sanitizePath(baseMask.replace(REPLACE_EXPR, function(type: string) {
-      let prop = type.substr(1, type.length - 2);
+      let prop = type.slice(1, -1);
       const flat = prop.startsWith("flat");
       if (flat) {
-        prop = prop.substr(4);
+        prop = prop.slice(4);
       }
       prop = `p_${prop}`;
       let rv = (prop in self) ?

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -176,8 +176,8 @@ export const parsePath = memoize(function parsePath(
   let base = name;
   let ext = "";
   if (idx >= 0) {
-    base = sanitizePath(name.substr(0, idx));
-    ext = sanitizePath(name.substr(idx + 1));
+    base = sanitizePath(name.slice(0, idx));
+    ext = sanitizePath(name.slice(idx + 1));
   }
 
   for (let i = 0; i < pieces.length;) {

--- a/lib/windowutils.ts
+++ b/lib/windowutils.ts
@@ -195,7 +195,7 @@ export function iconForPath(path: string, size = DEFAULT_ICON_SIZE) {
   if (file) {
     const idx = file.lastIndexOf(".");
     if (idx > 0) {
-      file = `file${file.substr(idx)}`;
+      file = `file${file.slice(idx)}`;
       file.replace(/\?.*?/g, "");
     }
     else {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.