### PR TITLE
Big filters update '22

### DIFF
--- a/data/filters.json
+++ b/data/filters.json
@@ -7,14 +7,14 @@
 	},
 	"deffilter-arch": {
 		"label": "Archives",
-		"expr": "/\\.(?:z(?:ip|[0-9]{2})|r(?:ar|[0-9]{2})|jar|bz2|gz|tar|rpm|7z(?:ip)?|lzma|xz)$/i",
+		"expr": "/\\.(?:[7gx]z|[jrt]ar|[7g]?zip|[rz][0-9]{2,}|bz2|rpm|lzma)$/i",
 		"type": 1,
 		"active": false,
 		"icon": "zip"
 	},
 	"deffilter-aud": {
 		"label": "Audio",
-		"expr": "/\\.(?:mp3|wav|og(?:g|a)|flac|midi?|rm|aac|wma|mka|ape|opus)$/i",
+		"expr": "/\\.(?:mp3|wav|og[ag]|flac|midi?|rm|aac|wma|mka|ape|opus)$/i",
 		"type": 3,
 		"active": false,
 		"icon": "mp3"
@@ -28,14 +28,14 @@
 	},
 	"deffilter-doc": {
 		"label": "Documents",
-		"expr": "/\\.(?:pdf|xlsx?|docx?|odf|odt|rtf|txt|nfo)$/i",
+		"expr": "/\\.(?:pdf|xlsx?|docx?|pp[st]x?|od[ft]|rtf|txt|nfo)$/i",
 		"type": 1,
 		"active": false,
 		"icon": "pdf"
 	},
 	"deffilter-img": {
 		"label": "Images",
-		"expr": "/\\.(?:jp(?:e?g|e|2)|gif|png|tiff?|bmp|ico|heic|heif|webp|jxr|wdp|dng|cr2|arw)$/i",
+		"expr": "/\\.(?:jp(?:e?g|e|2)|gif|png|tiff?|bmp|ico|hei[cf]|webp|jxr|wdp|dng|cr2|arw)$/i",
 		"type": 3,
 		"active": false,
 		"icon": "jpg"
@@ -63,7 +63,7 @@
 	},
 	"deffilter-vid": {
 		"label": "Videos",
-		"expr": "/\\.(?:mpeg|ra?m|avi|mp(?:g|e|4)|mov|divx|asf|qt|wmv|m\\dv|rv|vob|asx|ogm|ogv|webm|flv|mkv|f4v|m4v)$/i",
+		"expr": "/\\.(?:mp(?:g|eg?|4)|ra?m|avi|m[ko0-9]v|divx|as[fx]|qt|wmv|rv|vob|og[mv]|webm|f[4l]v|swf)$/i",
 		"type": 3,
 		"active": true,
 		"icon": "mkv"


### PR DESCRIPTION
**10 line**
7z(?:ip)? =>7z, 7zip
7z|gz|xz = [7gx]z
r(?:ar|[0-9]{2}) => rar, r[0-9]{2,}       // "," because of _3+ digit archive partitions_ as .r100 etc.
z(?:ip|[0-9]{2}) => zip, z[0-9]{2,}       // look above
jar|rar|tar = [jrt]ar
zip|7zip|gzip = [7g]?zip       // _what about .gzip format?_
r[0-9]{2,}|z[0-9]{2,} = [rz][0-9]{2,}
       // BTW resorted by format popularity

**17 line**
og(?:g|a) = og[ag]

**24, 45, 52, 59 lines**
OK

**31 line**
ppt, pptx, pps, ppsx => pp[st]x?       // _added Powerpoint formats_
odf|odt = od[ft]

**38 line**
heic|heif = hei[cf]

**66 line**
mpeg|mp(?:g|e|4) = mp(?:g|eg?|4)
mov|m\\dv|mkv|m4v = m[ko0-9]v       // https://stackoverflow.com/a/891741 - 0-9 works faster because of \d include not only arabic but all unicode digits, for example, unicode's ١۱߁१১੧૧୧௧౧೧൧๑໑１ mean "1" too
asf|asx = as[fx]
ogm|ogv = og[mv]
flv|f4v = f[4l]v
       // _also .swf added_